### PR TITLE
Atlas for TextureManager

### DIFF
--- a/atlas/atlas.go
+++ b/atlas/atlas.go
@@ -1,0 +1,91 @@
+package atlas
+
+import (
+	"image"
+
+	"github.com/hajimehoshi/ebiten/v2"
+)
+
+// Atlas is a minimal write-only container for sub-images, that
+// can be used with a DrawList to batch draw commands as triangles.
+type Atlas struct {
+	native    *ebiten.Image
+	set       *Set
+	unmanaged bool
+}
+
+type NewAtlasOptions struct {
+	// MinSize is the minimum size of images on the atlas.
+	// It is an optional hint to improve the allocation time
+	// of new images on the atlas.
+	MinSize image.Point
+	// Unmanaged is the same ebitengine's image option.
+	Unmanaged bool
+}
+
+func New(width, height int, opts *NewAtlasOptions) *Atlas {
+	var setOpts *NewSetOptions
+	var unmanaged bool
+	if opts != nil {
+		setOpts = &NewSetOptions{
+			MinSize: opts.MinSize,
+		}
+		unmanaged = opts.Unmanaged
+	}
+
+	return &Atlas{
+		native: ebiten.NewImageWithOptions(
+			image.Rect(0, 0, width, height),
+			&ebiten.NewImageOptions{
+				Unmanaged: unmanaged,
+			},
+		),
+		set: NewSet(width, height, setOpts),
+
+		unmanaged: unmanaged,
+	}
+}
+
+// Image returns the full atlas image.
+func (a *Atlas) Image() *ebiten.Image {
+	return a.native
+}
+
+// Bounds returns the bounds of the atlas.
+func (a *Atlas) Bounds() image.Rectangle {
+	return a.native.Bounds()
+}
+
+// NewImage allocates a rectangle area on the atlas and
+// returns the corresponding image.
+// It returns a nil if there was no space to allocate the region
+// specified by width, height.
+func (a *Atlas) NewImage(width, height int) *Image {
+	r := image.Rect(0, 0, width, height)
+	img := &Image{
+		atlas:  a,
+		bounds: &r,
+	}
+	if !a.set.Insert(img.bounds) {
+		return nil
+	}
+
+	return img
+}
+
+// SubImage returns an image matching a specific region of the atlas.
+// It is useful if you want to create the atlas from a spritesheet and
+// that you know the regions of you sub images.
+func (a *Atlas) SubImage(bounds image.Rectangle) *Image {
+	return &Image{
+		atlas:  a,
+		bounds: &bounds,
+	}
+}
+
+// Free frees a region on the atlas, making it available for next
+// allocations.
+func (a *Atlas) Free(img *Image) {
+	img.Image().Clear()
+	a.set.Free(img.bounds)
+}

--- a/atlas/image.go
+++ b/atlas/image.go
@@ -1,0 +1,49 @@
+package atlas
+
+import (
+	"image"
+
+	"github.com/hajimehoshi/ebiten/v2"
+)
+
+type Image struct {
+	atlas *Atlas
+
+	bounds *image.Rectangle
+}
+
+func (i *Image) Atlas() *Atlas {
+	return i.atlas
+}
+
+func (i *Image) Bounds() image.Rectangle {
+	return *i.bounds
+}
+
+func (i *Image) Image() *ebiten.Image {
+	return i.atlas.native.SubImage(*i.bounds).(*ebiten.Image)
+}
+
+func (i *Image) DrawImage(src *ebiten.Image, opts *ebiten.DrawImageOptions) {
+	if opts == nil {
+		opts = &ebiten.DrawImageOptions{}
+	}
+	dst := i.Image()
+	geom := opts.GeoM
+	opts.GeoM.Translate(
+		float64(dst.Bounds().Min.X),
+		float64(dst.Bounds().Min.Y),
+	)
+	opts.GeoM.Concat(geom)
+	dst.DrawImage(src, opts)
+}
+
+func (i *Image) SubImage(bounds image.Rectangle) *Image {
+	bounds = bounds.Add(i.bounds.Min)
+
+	return &Image{
+		atlas: i.atlas,
+
+		bounds: &bounds,
+	}
+}

--- a/atlas/set.go
+++ b/atlas/set.go
@@ -1,0 +1,243 @@
+package atlas
+
+import (
+	"image"
+	"slices"
+	"sort"
+)
+
+type Set struct {
+	width   int
+	height  int
+	rects   []*image.Rectangle
+	empties []image.Rectangle
+	tmps    []image.Rectangle
+
+	minSize image.Point
+}
+
+type NewSetOptions struct {
+	MinSize image.Point
+}
+
+func NewSet(width, height int, opts *NewSetOptions) *Set {
+	s := &Set{
+		width:  width,
+		height: height,
+		empties: []image.Rectangle{
+			image.Rect(0, 0, width, height),
+		},
+	}
+	if opts != nil {
+		s.minSize = opts.MinSize
+	}
+	s.minSize.X = max(s.minSize.X, 1)
+	s.minSize.Y = max(s.minSize.Y, 1)
+
+	return s
+}
+
+func appendEmptyNeighbours(rects []image.Rectangle, parent, filled image.Rectangle) []image.Rectangle {
+	if !filled.In(parent) {
+		return append(rects, parent)
+	}
+	if filled.Min.X > parent.Min.X {
+		rects = append(rects, image.Rect(
+			parent.Min.X,
+			parent.Min.Y,
+			filled.Min.X,
+			parent.Max.Y,
+		))
+	}
+	if filled.Max.X < parent.Max.X {
+		rects = append(rects, image.Rect(
+			filled.Max.X,
+			parent.Min.Y,
+			parent.Max.X,
+			parent.Max.Y,
+		))
+	}
+	if filled.Min.Y > parent.Min.Y {
+		rects = append(rects, image.Rect(
+			parent.Min.X,
+			parent.Min.Y,
+			parent.Max.X,
+			filled.Min.Y,
+		))
+	}
+	if filled.Max.Y < parent.Max.Y {
+		rects = append(rects, image.Rect(
+			parent.Min.X,
+			filled.Max.Y,
+			parent.Max.X,
+			parent.Max.Y,
+		))
+	}
+	return rects
+}
+
+func (s *Set) sanitizeEmptyRegions(current []image.Rectangle) {
+	// Sort empty regions by size to ensure smaller regions are evicted if
+	// contained by bigger ones
+	sort.SliceStable(current, func(i, j int) bool {
+		si := current[i].Dx() * current[i].Dy()
+		sj := current[j].Dx() * current[j].Dy()
+		return si > sj
+	})
+	s.empties = s.empties[:0]
+	for i := range current {
+		if current[i].Dx() < s.minSize.X || current[i].Dy() < s.minSize.Y {
+			continue
+		}
+		var contained bool
+		// Filter out any duplicate or any empty region that is already
+		// contained by another one
+		for _, empty := range s.empties {
+			if current[i] == empty || current[i].In(empty) {
+				contained = true
+				break
+			}
+		}
+		if contained {
+			continue
+		}
+		s.empties = append(s.empties, current[i])
+	}
+}
+
+func (s *Set) Insert(rect *image.Rectangle) bool {
+	// Set the free regions from last insertion
+	s.tmps = append(s.tmps[:0], s.empties...)
+	// Filter out too small regions
+	s.tmps = s.tmps[:0]
+	for _, r := range s.empties {
+		if rect.Dx() > r.Dx() || rect.Dy() > r.Dy() {
+			continue
+		}
+		s.tmps = append(s.tmps, r)
+	}
+	// Abort if no available rectangle
+	if len(s.tmps) == 0 {
+		return false
+	}
+	// Find best rectangle (the closest to top left corner)
+	best := s.tmps[0]
+	bs := best.Min.X + best.Min.Y
+	for i := range s.tmps {
+		if d := s.tmps[i].Min.X + s.tmps[i].Min.Y; d < bs {
+			best = s.tmps[i]
+			bs = d
+		}
+	}
+	// Insert the provided rectangle with the origin of the best free region
+	*rect = rect.Add(best.Min)
+	s.rects = append(s.rects, rect)
+	// Split the regions that used to be empty with new empty neighbours
+	s.tmps = s.tmps[:0]
+	for i := range s.empties {
+		if ix := rect.Intersect(s.empties[i]); !ix.Empty() {
+			s.tmps = appendEmptyNeighbours(s.tmps, s.empties[i], ix)
+		} else {
+			s.tmps = append(s.tmps, s.empties[i])
+		}
+	}
+	// Prepare the empty regions for next insertion
+	s.sanitizeEmptyRegions(s.tmps)
+
+	return true
+}
+
+func intersectAny(r image.Rectangle, rectangles []image.Rectangle) bool {
+	for i := range rectangles {
+		if !rectangles[i].Intersect(r).Empty() {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *Set) Free(rect *image.Rectangle) {
+	if rect == nil || len(s.rects) == 0 {
+		return
+	}
+	idx := slices.Index(s.rects, rect)
+	if idx != -1 {
+		s.rects = slices.Delete(s.rects, idx, idx+1)
+
+		// Try to grow the just freed region until it's not possible anymore
+		// TODO: awful algorithm but curiously fast enough for the moment
+
+		// Grow by X
+		pushX := func(base image.Rectangle) image.Rectangle {
+			// Filter Y-intersecting rectangles only
+			s.tmps = s.tmps[:0]
+			for _, r := range s.rects {
+				if r.Max.Y >= base.Min.Y && r.Min.Y <= base.Max.Y {
+					s.tmps = append(s.tmps, *r)
+				}
+			}
+			for base.Min.X > 0 {
+				base.Min.X -= 1
+				if intersectAny(base, s.tmps) {
+					base.Min.X += 1
+					break
+				}
+			}
+			for base.Max.X < s.width {
+				base.Max.X += 1
+				if intersectAny(base, s.tmps) {
+					base.Max.X -= 1
+					break
+				}
+			}
+			return base
+		}
+		// Grow by Y
+		pushY := func(base image.Rectangle) image.Rectangle {
+			// Filter X-intersecting rectangles only
+			s.tmps = s.tmps[:0]
+			for _, r := range s.rects {
+				if r.Max.X >= base.Min.X && r.Min.X <= base.Max.X {
+					s.tmps = append(s.tmps, *r)
+				}
+			}
+			for base.Min.Y > 0 {
+				base.Min.Y -= 1
+				if intersectAny(base, s.tmps) {
+					base.Min.Y += 1
+					break
+				}
+			}
+			for base.Max.Y < s.height {
+				base.Max.Y += 1
+				if intersectAny(base, s.tmps) {
+					base.Max.Y -= 1
+					break
+				}
+			}
+			return base
+		}
+
+		// Extend the region by X first
+		rX := pushX(*rect)
+		rX = pushY(rX)
+		// Extend the region by Y second
+		rY := pushY(*rect)
+		rY = pushX(rY)
+		// Keep the largest region
+		sX := rX.Dx() * rX.Dy()
+		sY := rY.Dx() * rY.Dy()
+		var freed image.Rectangle
+		if sX > sY {
+			freed = rX
+		} else {
+			freed = rY
+		}
+
+		s.empties = append(s.empties, freed)
+		s.tmps = append(s.tmps[:0], s.empties...)
+
+		// Sanitize empty space
+		s.sanitizeEmptyRegions(s.tmps)
+	}
+}

--- a/dualgrid/dualgrid.go
+++ b/dualgrid/dualgrid.go
@@ -123,8 +123,8 @@ func (self *DualGrid) SetTile(x, y int, value TileType) {
 // AddMaterial adds a new material to the grid, creating the necessary variants from a mask.
 func (self *DualGrid) AddMaterial(material, mask *ebiten.Image) {
 	if material.Bounds().Dx() != self.tileSize || material.Bounds().Dy() != self.tileSize {
-		errMsh := fmt.Sprintf("Material isn't the right dimension: %dx%d, tile size: %d", material.Bounds().Dx(), material.Bounds().Dy(), self.tileSize)
-		log.Fatal(errors.New(errMsh))
+		errMsg := fmt.Sprintf("Material isn't the right dimension: %dx%d, tile size: %d", material.Bounds().Dx(), material.Bounds().Dy(), self.tileSize)
+		log.Fatal(errors.New(errMsg))
 	}
 
 	side := 4
@@ -132,7 +132,8 @@ func (self *DualGrid) AddMaterial(material, mask *ebiten.Image) {
 	num := side * side
 
 	if mask.Bounds().Dx() != side*self.tileSize || mask.Bounds().Dy() != side*self.tileSize {
-		log.Fatal(errors.New("Mask isn't the right dimension"))
+		errMsg := fmt.Sprintf("Mask isn't the right dimension: %dx%d, tile size: %d", mask.Bounds().Dx(), mask.Bounds().Dy(), self.tileSize)
+		log.Fatal(errors.New(errMsg))
 	}
 
 	opts := &ebiten.DrawImageOptions{}

--- a/dualgrid/dualgrid.go
+++ b/dualgrid/dualgrid.go
@@ -2,6 +2,7 @@ package dualgrid
 
 import (
 	"errors"
+	"fmt"
 	"image"
 	"log"
 
@@ -122,7 +123,8 @@ func (self *DualGrid) SetTile(x, y int, value TileType) {
 // AddMaterial adds a new material to the grid, creating the necessary variants from a mask.
 func (self *DualGrid) AddMaterial(material, mask *ebiten.Image) {
 	if material.Bounds().Dx() != self.tileSize || material.Bounds().Dy() != self.tileSize {
-		log.Fatal(errors.New("Material isn't the right dimension"))
+		errMsh := fmt.Sprintf("Material isn't the right dimension: %dx%d, tile size: %d", material.Bounds().Dx(), material.Bounds().Dy(), self.tileSize)
+		log.Fatal(errors.New(errMsh))
 	}
 
 	side := 4

--- a/engine.go
+++ b/engine.go
@@ -33,6 +33,10 @@ type Engine struct {
 	clearScreenEachFrame bool
 	clearColor           color.Color
 	cursorMode           ebiten.CursorModeType
+
+	// Atlas settings
+	atlasWidth  int
+	atlasHeight int
 }
 
 // Option is a functional option for configuring the engine.
@@ -95,6 +99,14 @@ func WithClearColor(col color.Color) Option {
 	}
 }
 
+// WithTextureAtlasSize sets the dimensions for the internal texture atlases.
+func WithTextureAtlasSize(w, h int) Option {
+	return func(e *Engine) {
+		e.atlasWidth = w
+		e.atlasHeight = h
+	}
+}
+
 // WithBackgroundDrawSystem adds a DrawSystem that renders before the scene.
 func WithBackgroundDrawSystem(sys any) Option {
 	return func(e *Engine) {
@@ -120,7 +132,6 @@ func WithUpdateSystem(sys UpdateSystem) Option {
 func NewEngine(opts ...Option) *Engine {
 	e := &Engine{
 		world:    NewWorld(),
-		tm:       NewTextureManager(),
 		fm:       NewFontManager(),
 		am:       NewAudioManager(44100),
 		sm:       NewSceneManager(),
@@ -133,11 +144,19 @@ func NewEngine(opts ...Option) *Engine {
 		windowWidth:           800,
 		windowHeight:          600,
 		windowTitle:           "Game",
+		atlasWidth:            2048, // Default atlas size
+		atlasHeight:           2048,
 		// ... default settings
 	}
+
+	// Apply all the functional options. This might override the defaults.
 	for _, opt := range opts {
 		opt(e)
 	}
+
+	// Initialize the texture manager with the (possibly overridden) atlas size.
+	e.tm = NewTextureManagerWithOptions(e.atlasWidth, e.atlasHeight)
+
 	return e
 }
 

--- a/textures.go
+++ b/textures.go
@@ -11,43 +11,80 @@ import (
 	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
 )
 
-// TextureManager manages loading and retrieving textures using a texture atlas
-// to optimize rendering performance. It packs multiple small textures into larger
-// atlas images to reduce the number of draw calls.
+// TextureManager manages loading and retrieving textures. It can operate in two
+// modes: using a texture atlas for performance, or managing individual textures
+// as a simple list.
 type TextureManager struct {
+	// --- Atlas Mode Fields ---
 	// atlases is a slice of texture atlases. A new atlas is created when the
-	// existing ones are full.
+	// existing ones are full. Only used when useAtlas is true.
 	atlases []*atlas.Atlas
 	// images is a slice of all the sub-images (textures) stored in the atlases.
-	// The index of this slice is used as the texture ID.
-	images []*atlas.Image
-	// atlasWidth is the width of the atlas textures.
-	atlasWidth int
-	// atlasHeight is the height of the atlas textures.
+	// The index of this slice is used as the texture ID. Only used when useAtlas is true.
+	images      []*atlas.Image
+	atlasWidth  int
 	atlasHeight int
+
+	// --- Non-Atlas Mode Fields ---
+	// textures is a simple slice of images. Only used when useAtlas is false.
+	textures []*ebiten.Image
+
+	// --- Configuration ---
+	useAtlas bool
 }
 
-// NewTextureManager creates a manager with a default white texture and a default
-// atlas size of 2048x2048.
-func NewTextureManager() *TextureManager {
-	return NewTextureManagerWithOptions(2048, 2048)
-}
+// TextureManagerOption is a functional option for configuring a TextureManager.
+type TextureManagerOption func(*TextureManager)
 
-// NewTextureManagerWithOptions creates a manager with a default white texture
-// and a custom atlas size.
-func NewTextureManagerWithOptions(atlasWidth, atlasHeight int) *TextureManager {
-	tm := &TextureManager{
-		atlasWidth:  atlasWidth,
-		atlasHeight: atlasHeight,
+// WithAtlas enables or disables the texture atlas system.
+func WithAtlas(enabled bool) TextureManagerOption {
+	return func(tm *TextureManager) {
+		tm.useAtlas = enabled
 	}
-	// Create the first atlas.
-	tm.atlases = append(tm.atlases, atlas.New(tm.atlasWidth, tm.atlasHeight, nil))
+}
 
-	// Add a 1x1 white texture as the default texture (ID 0). This is useful
-	// as a fallback for invalid texture IDs.
+// WithAtlasSize sets the dimensions for the internal texture atlases.
+// This implicitly enables the atlas system.
+func WithAtlasSize(w, h int) TextureManagerOption {
+	return func(tm *TextureManager) {
+		tm.useAtlas = true
+		tm.atlasWidth = w
+		tm.atlasHeight = h
+	}
+}
+
+// NewTextureManager creates a manager with a default white texture.
+// By default, the atlas system is disabled. Use WithAtlas(true) or
+// WithAtlasSize(...) to enable it.
+func NewTextureManager(opts ...TextureManagerOption) *TextureManager {
+	tm := &TextureManager{
+		// Default values
+		useAtlas:    false,
+		atlasWidth:  2048,
+		atlasHeight: 2048,
+	}
+
+	for _, opt := range opts {
+		opt(tm)
+	}
+
+	// Add a 1x1 white texture as the default texture (ID 0).
 	white := ebiten.NewImage(1, 1)
 	white.Fill(color.White)
-	tm.Add(white)
+
+	// Initialize the appropriate storage and add the white texture.
+	if tm.useAtlas {
+		tm.atlases = append(tm.atlases, atlas.New(tm.atlasWidth, tm.atlasHeight, nil))
+		// The Add method will handle adding the white texture to the atlas.
+	} else {
+		tm.textures = append(tm.textures, white)
+	}
+
+	// If using the atlas, we need to call Add to place the white texture.
+	// In non-atlas mode, it's already in the slice.
+	if tm.useAtlas {
+		tm.Add(white)
+	}
 
 	return tm
 }
@@ -92,17 +129,37 @@ func (tm *TextureManager) decodeImage(rawImage *[]byte) *image.Image {
 // Get retrieves a texture by its ID. If the ID is invalid, it returns the
 // default white texture.
 func (tm *TextureManager) Get(id int) *ebiten.Image {
-	if id < 0 || id >= len(tm.images) {
-		return tm.images[0].Image() // Fallback to white texture (ID 0)
+	if tm.useAtlas {
+		if id < 0 || id >= len(tm.images) {
+			return tm.images[0].Image() // Fallback to white texture (ID 0)
+		}
+		return tm.images[id].Image()
 	}
-	return tm.images[id].Image()
+
+	if id < 0 || id >= len(tm.textures) {
+		return tm.textures[0] // Fallback to white texture (ID 0)
+	}
+	return tm.textures[id]
 }
 
-// Add adds a pre-existing *ebiten.Image to an atlas and returns its new ID.
-// It iterates through the existing atlases to find a space for the image. If no
-// space is found, a new atlas is created. If the image is larger than the
-// default atlas size, a new, custom-sized atlas is created for it.
+// AtlasSize returns the default dimensions of the atlases created by the manager.
+// Returns 0, 0 if the atlas system is not in use.
+func (tm *TextureManager) AtlasSize() (int, int) {
+	if !tm.useAtlas {
+		return 0, 0
+	}
+	return tm.atlasWidth, tm.atlasHeight
+}
+
+// Add adds a pre-existing *ebiten.Image to the manager and returns its new ID.
+// The behavior depends on whether the atlas system is enabled.
 func (tm *TextureManager) Add(img *ebiten.Image) int {
+	if !tm.useAtlas {
+		id := len(tm.textures)
+		tm.textures = append(tm.textures, img)
+		return id
+	}
+
 	imgWidth := img.Bounds().Dx()
 	imgHeight := img.Bounds().Dy()
 	var atlasImg *atlas.Image

--- a/textures.go
+++ b/textures.go
@@ -6,73 +6,141 @@ import (
 	"image/color"
 	_ "image/png"
 
+	"github.com/edwinsyarief/katsu2d/atlas"
 	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
 )
 
-// TextureManager manages loading and retrieving textures.
+// TextureManager manages loading and retrieving textures using a texture atlas
+// to optimize rendering performance. It packs multiple small textures into larger
+// atlas images to reduce the number of draw calls.
 type TextureManager struct {
-	textures []*ebiten.Image
+	// atlases is a slice of texture atlases. A new atlas is created when the
+	// existing ones are full.
+	atlases []*atlas.Atlas
+	// images is a slice of all the sub-images (textures) stored in the atlases.
+	// The index of this slice is used as the texture ID.
+	images []*atlas.Image
+	// atlasWidth is the width of the atlas textures.
+	atlasWidth int
+	// atlasHeight is the height of the atlas textures.
+	atlasHeight int
 }
 
-// NewTextureManager creates a manager with a default white texture.
+// NewTextureManager creates a manager with a default white texture and a default
+// atlas size of 2048x2048.
 func NewTextureManager() *TextureManager {
-	tm := &TextureManager{}
+	return NewTextureManagerWithOptions(2048, 2048)
+}
+
+// NewTextureManagerWithOptions creates a manager with a default white texture
+// and a custom atlas size.
+func NewTextureManagerWithOptions(atlasWidth, atlasHeight int) *TextureManager {
+	tm := &TextureManager{
+		atlasWidth:  atlasWidth,
+		atlasHeight: atlasHeight,
+	}
+	// Create the first atlas.
+	tm.atlases = append(tm.atlases, atlas.New(tm.atlasWidth, tm.atlasHeight, nil))
+
+	// Add a 1x1 white texture as the default texture (ID 0). This is useful
+	// as a fallback for invalid texture IDs.
 	white := ebiten.NewImage(1, 1)
 	white.Fill(color.White)
-	tm.textures = append(tm.textures, white)
+	tm.Add(white)
+
 	return tm
 }
 
-// Load loads an image from file and returns its ID.
-func (self *TextureManager) Load(path string) (int, error) {
-	var result *ebiten.Image
+// Load loads an image from a file, adds it to an atlas, and returns its ID.
+func (tm *TextureManager) Load(path string) (int, error) {
 	_, img, err := ebitenutil.NewImageFromFile(path)
 	if err != nil {
-		panic(err)
+		return 0, err
 	}
 
-	result = ebiten.NewImageFromImage(img)
-	id := len(self.textures)
-	self.textures = append(self.textures, result)
-
-	return id, nil
+	return tm.Add(ebiten.NewImageFromImage(img)), nil
 }
 
-// LoadEmbedded loads an image from embedded file and returns its ID.
-func (self *TextureManager) LoadEmbedded(path string) int {
+// LoadEmbedded loads an image from an embedded file, adds it to an atlas, and
+// returns its ID.
+func (tm *TextureManager) LoadEmbedded(path string) int {
 	b := openEmbeddedFile(path)
-	return self.fromByte(b)
+	return tm.fromByte(b)
 }
 
-func (self *TextureManager) LoadFromAssetPacker(path string) int {
+// LoadFromAssetPacker loads an image from a bundled asset file, adds it to an
+// atlas, and returns its ID.
+func (tm *TextureManager) LoadFromAssetPacker(path string) int {
 	b := openBundledFile(path)
-	return self.fromByte(b)
+	return tm.fromByte(b)
 }
 
-func (self *TextureManager) fromByte(content []byte) int {
-	img := ebiten.NewImageFromImage(*self.decodeImage(&content))
-	id := len(self.textures)
-	self.textures = append(self.textures, img)
-	return id
+// fromByte decodes an image from a byte slice, adds it to an atlas, and returns
+// its ID.
+func (tm *TextureManager) fromByte(content []byte) int {
+	img := ebiten.NewImageFromImage(*tm.decodeImage(&content))
+	return tm.Add(img)
 }
 
-func (self *TextureManager) decodeImage(rawImage *[]byte) *image.Image {
+// decodeImage decodes a byte slice into an image.Image.
+func (tm *TextureManager) decodeImage(rawImage *[]byte) *image.Image {
 	img, _, _ := image.Decode(bytes.NewReader(*rawImage))
 	return &img
 }
 
-// Get retrieves a texture by ID, falling back to white if invalid.
-func (self *TextureManager) Get(id int) *ebiten.Image {
-	if id < 0 || id >= len(self.textures) {
-		return self.textures[0] // Fallback to white
+// Get retrieves a texture by its ID. If the ID is invalid, it returns the
+// default white texture.
+func (tm *TextureManager) Get(id int) *ebiten.Image {
+	if id < 0 || id >= len(tm.images) {
+		return tm.images[0].Image() // Fallback to white texture (ID 0)
 	}
-	return self.textures[id]
+	return tm.images[id].Image()
 }
 
-// Add adds a pre-existing *ebiten.Image to the manager and returns its new ID.
-func (self *TextureManager) Add(img *ebiten.Image) int {
-	id := len(self.textures)
-	self.textures = append(self.textures, img)
+// Add adds a pre-existing *ebiten.Image to an atlas and returns its new ID.
+// It iterates through the existing atlases to find a space for the image. If no
+// space is found, a new atlas is created. If the image is larger than the
+// default atlas size, a new, custom-sized atlas is created for it.
+func (tm *TextureManager) Add(img *ebiten.Image) int {
+	imgWidth := img.Bounds().Dx()
+	imgHeight := img.Bounds().Dy()
+	var atlasImg *atlas.Image
+
+	// Handle images that are larger than the standard atlas size.
+	if imgWidth > tm.atlasWidth || imgHeight > tm.atlasHeight {
+		// Create a new atlas specifically for this large image.
+		newAtlas := atlas.New(imgWidth, imgHeight, nil)
+		tm.atlases = append(tm.atlases, newAtlas)
+		atlasImg = newAtlas.NewImage(imgWidth, imgHeight)
+	} else {
+		// For regular-sized images, try to fit them into an existing atlas.
+		for _, a := range tm.atlases {
+			atlasImg = a.NewImage(imgWidth, imgHeight)
+			if atlasImg != nil {
+				break // Found a spot
+			}
+		}
+
+		// If no space was found, create a new atlas with the default size.
+		if atlasImg == nil {
+			newAtlas := atlas.New(tm.atlasWidth, tm.atlasHeight, nil)
+			tm.atlases = append(tm.atlases, newAtlas)
+			atlasImg = newAtlas.NewImage(imgWidth, imgHeight)
+		}
+	}
+
+	// If atlasImg is still nil, it means we couldn't allocate space even in a
+	// new atlas, which indicates a problem.
+	if atlasImg == nil {
+		panic("katsu2d: failed to allocate image on atlas")
+	}
+
+	// Draw the image onto the atlas.
+	atlasImg.DrawImage(img, nil)
+
+	// Add the new atlas image to the list and return its ID.
+	id := len(tm.images)
+	tm.images = append(tm.images, atlasImg)
 	return id
 }


### PR DESCRIPTION
Atlas is a new feature for TextureManager, and it is optional. By default, the atlas will be disabled. But we can enable it, so when we call functions: Load, LoadEmbedded, LoadFromAssetPacker, it will automatically build an atlas and add the image to the region. This implementation is copied from: https://github.com/Zyko0/Ebiary/tree/main/atlas.